### PR TITLE
Refine release workflow signing setup

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,125 @@
+name: Build and Release APK
+
+on:
+  push:
+    paths:
+      - 'Speedtest-Android/app/src/main/assets/ServerList.json'
+      - 'Speedtest-Android/app/src/main/assets/serverlist.json'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+
+      - name: Install Android SDK components
+        run: |
+          set -euo pipefail
+          sdk_root="${ANDROID_SDK_ROOT:-$ANDROID_HOME}"
+          if [ -z "${sdk_root}" ] || [ ! -d "${sdk_root}" ]; then
+            echo "Unable to locate Android SDK root" >&2
+            exit 1
+          fi
+          yes | "${sdk_root}/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null
+          yes | "${sdk_root}/cmdline-tools/latest/bin/sdkmanager" \
+            "platforms;android-28" \
+            "build-tools;29.0.0"
+
+      - name: Cache Gradle files
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+        working-directory: Speedtest-Android
+
+      - name: Determine release version
+        id: version
+        run: |
+          release_version="$(date -u +'%Y.%m.%d')"
+          release_version_code="$(date -u +'%Y%m%d')"
+          echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"
+          echo "release_version_code=${release_version_code}" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare signing key
+        id: signing
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" ]; then
+            echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 --decode > Speedtest-Android/release.keystore
+            echo "keystore_path=${GITHUB_WORKSPACE}/Speedtest-Android/release.keystore" >> "$GITHUB_OUTPUT"
+            echo "keystore_password=${{ secrets.RELEASE_KEYSTORE_PASSWORD }}" >> "$GITHUB_OUTPUT"
+            echo "key_alias=${{ secrets.RELEASE_KEY_ALIAS }}" >> "$GITHUB_OUTPUT"
+            echo "key_password=${{ secrets.RELEASE_KEY_PASSWORD }}" >> "$GITHUB_OUTPUT"
+          else
+            keytool -genkeypair \
+              -alias librespeed \
+              -keyalg RSA \
+              -keysize 2048 \
+              -validity 36500 \
+              -storepass android \
+              -keypass android \
+              -dname "CN=LibreSpeed,O=LibreSpeed,C=US" \
+              -keystore Speedtest-Android/release.keystore
+            echo "keystore_path=${GITHUB_WORKSPACE}/Speedtest-Android/release.keystore" >> "$GITHUB_OUTPUT"
+            echo "keystore_password=android" >> "$GITHUB_OUTPUT"
+            echo "key_alias=librespeed" >> "$GITHUB_OUTPUT"
+            echo "key_password=android" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build release APK
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.release_version }}
+          RELEASE_VERSION_CODE: ${{ steps.version.outputs.release_version_code }}
+          RELEASE_KEYSTORE_PATH: ${{ steps.signing.outputs.keystore_path }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ steps.signing.outputs.keystore_password }}
+          RELEASE_KEY_ALIAS: ${{ steps.signing.outputs.key_alias }}
+          RELEASE_KEY_PASSWORD: ${{ steps.signing.outputs.key_password }}
+        run: ./gradlew assembleRelease
+        working-directory: Speedtest-Android
+
+      - name: Prepare APK artifact
+        run: |
+          set -euo pipefail
+          APK_SOURCE="Speedtest-Android/app/build/outputs/apk/release/app-release.apk"
+          if [ ! -f "$APK_SOURCE" ]; then
+            echo "Expected APK not found at $APK_SOURCE" >&2
+            exit 1
+          fi
+          cp "$APK_SOURCE" "Speedtest-Android/librespeed-${{ steps.version.outputs.release_version }}.apk"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: librespeed-${{ steps.version.outputs.release_version }}.apk
+          path: Speedtest-Android/librespeed-${{ steps.version.outputs.release_version }}.apk
+          if-no-files-found: error
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.release_version }}
+          name: ${{ steps.version.outputs.release_version }}
+          body: |
+            Automated build triggered by an update to the server list.
+          files: Speedtest-Android/librespeed-${{ steps.version.outputs.release_version }}.apk
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: false
+          overwrite: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /_PRIVATE
 .directory
+*.keystore
+*.jks
 
  

--- a/Speedtest-Android/app/.gitignore
+++ b/Speedtest-Android/app/.gitignore
@@ -1,1 +1,3 @@
 /build
+*.keystore
+*.jks

--- a/Speedtest-Android/app/build.gradle
+++ b/Speedtest-Android/app/build.gradle
@@ -1,18 +1,44 @@
 apply plugin: 'com.android.application'
 
+def releaseVersion = System.getenv("RELEASE_VERSION") ?: '1.2.3'
+def releaseVersionCodeValue = System.getenv("RELEASE_VERSION_CODE")
+def releaseVersionCode = releaseVersionCodeValue?.isInteger() ? releaseVersionCodeValue.toInteger() : 1
+
+def releaseKeystorePath = System.getenv("RELEASE_KEYSTORE_PATH")
+def releaseKeystorePassword = System.getenv("RELEASE_KEYSTORE_PASSWORD") ?: ''
+def releaseKeyAlias = System.getenv("RELEASE_KEY_ALIAS") ?: ''
+def releaseKeyPassword = System.getenv("RELEASE_KEY_PASSWORD") ?: ''
+def hasReleaseKeystore = releaseKeystorePath ? file(releaseKeystorePath).exists() : false
+
 android {
     compileSdkVersion 28
     buildToolsVersion "29.0.0"
+
+    signingConfigs {
+        maybeCreate('release')
+        release {
+            if (hasReleaseKeystore) {
+                storeFile file(releaseKeystorePath)
+                storePassword releaseKeystorePassword
+                keyAlias releaseKeyAlias
+                keyPassword releaseKeyPassword
+            }
+        }
+    }
+
     defaultConfig {
-        applicationId "your.name.here.speedtest"
+        applicationId "com.legiz_ru.librespeed"
         minSdkVersion 15
         targetSdkVersion 28
-        versionCode 9
-        versionName '1.2.3'
+        versionCode releaseVersionCode
+        versionName releaseVersion
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
+            if (hasReleaseKeystore) {
+                signingConfig signingConfigs.release
+            }
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/Speedtest-Android/app/src/main/AndroidManifest.xml
+++ b/Speedtest-Android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="your.name.here.speedtest">
+    package="com.legiz_ru.librespeed">
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- remove the bundled keystore and ignore future keystore artifacts so the repository stays binary-free
- make the Android project pick up the requested package id, date-based version, and optional signing credentials from environment variables
- update the GitHub Actions workflow to derive the release tag/version code, provision a keystore from secrets or generate one on the fly, and build the signed APK artifact
- install the required Android platform and build tools before assembling the release APK in CI

## Testing
- ./gradlew assembleRelease *(fails locally because the container JDK is too new for the legacy Gradle wrapper; the workflow pins Java 8 on GitHub runners)*

------
https://chatgpt.com/codex/tasks/task_e_68d1186a3afc832c9d6823bdfc1fcac5